### PR TITLE
英語版の生成されるヘルプ中に含まれていた日本語を英語にした

### DIFF
--- a/autoload/vimhelpgenerator.vim
+++ b/autoload/vimhelpgenerator.vim
@@ -627,7 +627,7 @@ function! s:_en_words() "{{{
   return {'summary': 'a summary', 'contents': 'CONTENTS', 'introduction': 'INTRODUCTION', 'introduction_preface': '*%s* is a Vim plugin ',
     \ 'latest-version': 'Latest version:', 'usage': 'USAGE', 'interface': 'INTERFACE',
     \ 'variables': 'VARIABLES', 'default-value': 'default value: ', 'commands': 'COMMANDS', 'buffer-local-command': 'buffer local command',
-    \ 'lines': 'lines', 'default': 'default:', 'whole-file': 'whole file', 'key-mappings': 'KEY-MAPPINGS', 'enablemodes': '有効モード',
+    \ 'lines': 'lines', 'default': 'default:', 'whole-file': 'whole file', 'key-mappings': 'KEY-MAPPINGS', 'enablemodes': 'enable modes',
     \ 'buffer-local-mapping': 'buffer local mapping', 'defaultmappings_global': 'default mappings (global)', 'defaultmappings_local': 'default mapping (buffer local)', 'defaultmappings': 'default mappings', 'localdefaultmappings': 'local default mappings',
     \ 'modeshortname': {'n': 'normal', 'x': 'visual', 's': 'select', 'o': 'operator', 'i': 'insert', 'c': 'commandline'},
     \ 'modename': {'n': 'normal mode', 'x': 'visual mode', 's': 'select mode', 'o': 'operator mode', 'i': 'insert mode', 'c': 'commandline'},


### PR DESCRIPTION
`let g:vimhelpgenerator_defaultlanguage = 'en'`
とし、英語版のヘルプを作成した際に、作成された英語版のヘルプのキーマッピングの項目において、
『有効モード』
という日本語が含まれていたので、その部分が
『enable mode』
となるようにしました。
